### PR TITLE
Entity can't get more damage than his health

### DIFF
--- a/src/pocketmine/event/entity/EntityDamageEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageEvent.php
@@ -85,7 +85,8 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 			$this->setDamage(-($this->getDamage(self::MODIFIER_BASE) * 0.20 * ($entity->getEffect(Effect::DAMAGE_RESISTANCE)->getAmplifier() + 1)), self::MODIFIER_RESISTANCE);
 		}
 	}
-
+                if($entity->getHealth() < ($damage->getDamage()){
+                $entity->setHealth($entity->getHealth() - ($entity->getHealth()));;
 	/**
 	 * @return int
 	 */


### PR DESCRIPTION
Entity can't get more damage than his health
I try to do this because there is a bug.. When is a player get more damage than his heath the player dies but absulutely not normally and the player have to quit and rejoin, but if player get damage = his health he can normally respawn
Im not sure my work is working :D but i hope. And sry for my bad english :)