### PR TITLE
Fix for new door types not being registered

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -666,6 +666,14 @@ class Item{
 			self::$list[self::GOLDEN_APPLE] = GoldenApple::class;
 			self::$list[self::SIGN] = Sign::class;
 			self::$list[self::OAK_DOOR] = OakDoor::class;
+			
+			self::$list[self::ACACIA_DOOR] = AcaciaDoor::class;
+			self::$list[self::BIRCH_DOOR] = BirchDoor::class;
+			self::$list[self::DARK_OAK_DOOR] = DarkOakDoor::class;
+			self::$list[self::JUNGLE_DOOR] = JungleDoor::class;
+			self::$list[self::SPRUCE_DOOR] = SpruceDoor::class;
+			self::$list[self::IRON_DOOR] = IronDoor::class;	
+
 			self::$list[self::BUCKET] = Bucket::class;
 			
 			self::$list[self::MINECART] = Minecart::class;


### PR DESCRIPTION
Fix for new door types not being registered

Iron doors don't open - this will be a separate issue