### PR TITLE
Fix handle exception in /src/pocketmine/level/format/mcregion/Chunk 126

### DIFF
--- a/src/pocketmine/level/format/mcregion/Chunk.php
+++ b/src/pocketmine/level/format/mcregion/Chunk.php
@@ -123,7 +123,11 @@ class Chunk extends BaseFullChunk{
 	}
 
 	public function getBlockId($x, $y, $z){
-		return ord($this->blocks{($x << 11) | ($z << 7) | $y});
+		try {
+			return ord($this->blocks{($x << 11) | ($z << 7) | $y});
+		} catch (Exception $e) {
+			return 0;
+		}
 	}
 
 	public function setBlockId($x, $y, $z, $id){


### PR DESCRIPTION
Error: Uninitialized string offset: -1
File: /src/pocketmine/level/format/mcregion/Chunk
Line: 126

fix should help to prevent server crashes on uninitialized string offset