### PR TITLE
Fix handle exception in /src/pocketmine/level/format/mcregion/Chunk 127

### DIFF
--- a/src/pocketmine/level/format/mcregion/Chunk.php
+++ b/src/pocketmine/level/format/mcregion/Chunk.php
@@ -123,11 +123,10 @@ class Chunk extends BaseFullChunk{
 	}
 
 	public function getBlockId($x, $y, $z){
-		try {
+		if(!empty($this->blocks{($x << 11) | ($z << 7) | $y})) {
 			return ord($this->blocks{($x << 11) | ($z << 7) | $y});
-		} catch (Exception $e) {
-			return 0;
 		}
+		return 0;
 	}
 
 	public function setBlockId($x, $y, $z, $id){


### PR DESCRIPTION
updated fix to prevent the StringOutOfBoundsException and prevent server crash 

Error: Uninitialized string offset: -1
File: /src/pocketmine/level/format/mcregion/Chunk
Line: 127
Type: notice

if the blockId is out of bound, it return's 0 instead.
its the replacment for the previous patch-chunk-getblockid